### PR TITLE
Point issue triage at GitHub; tidy overlay Svelte modules

### DIFF
--- a/.cursor/rules/skill-maintenance.mdc
+++ b/.cursor/rules/skill-maintenance.mdc
@@ -13,7 +13,7 @@ When you change any of the following, update the corresponding skill(s) in `.cur
 | package.json scripts (dev/build/zip) or new build targets | wxt-svelte-extension, releases-changesets if release steps change |
 | E2E layout (e2e/tests, e2e/pages, fixture file path or name) | e2e-playwright-extension |
 | Release workflow (.changeset/, release steps, workflow_dispatch) | releases-changesets |
-| Issue refinement format or label set (docs/ISSUE_REFINEMENTS.md) | issue-refinement-triage |
+| Issue refinement format or label set (issue-refinement-triage template) | issue-refinement-triage |
 | New recurring “known issue” that should guide extension code | wxt-svelte-extension/reference.md |
 
 Read the current skill file before editing so the update stays consistent with existing structure and wording.

--- a/.cursor/skills/issue-refinement-triage/SKILL.md
+++ b/.cursor/skills/issue-refinement-triage/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: issue-refinement-triage
-description: Refines GitHub issues into the ISSUE_REFINEMENTS format and keeps docs/ISSUE_REFINEMENTS.md in sync. Use when triaging issues, refining a new issue, updating the refinements doc, or when the user asks to refine an issue or add to refinements.
+description: Refines GitHub issues using the block template and label table below. Tracking lives on GitHub; use when triaging issues, refining a new issue, or when the user asks to refine an issue.
 ---
 
 # Issue Refinement and Triage
 
 ## Canonical source
 
-Read [docs/ISSUE_REFINEMENTS.md](docs/ISSUE_REFINEMENTS.md) for the current open/closed list and label table before editing.
+Use **GitHub issues** for open/closed tracking and descriptions. This file defines the **label table** and **issue block template** only.
 
 ## Issue block template
 
@@ -40,5 +40,5 @@ Suggest only these labels; use space-separated list in the block.
 ## Workflow
 
 1. **New or raw issue:** Propose labels (from the table) and a one-line **Refined** that scopes or clarifies the issue.
-2. **Updating ISSUE_REFINEMENTS:** Add new refined issues under "Open issues (refined)". When an issue is closed, move its block to "Closed issues (reference)" and keep the same format.
+2. **GitHub:** Update the issue body or add a triage comment using the block template so the refined scope stays visible on the issue.
 3. **My comments:** Reserved for maintainer notes (priority, blockers, batching). Leave as `*(add notes here)*` if no note.

--- a/.cursor/skills/pr-from-issue/SKILL.md
+++ b/.cursor/skills/pr-from-issue/SKILL.md
@@ -9,7 +9,7 @@ Use GitHub MCP (server `user-github`) for all GitHub actions. Before calling any
 
 ## Quick decision
 
-1. **Issue:** From conversation (e.g. "issue #5") or search — identify the main issue #M. If none exists, create one via GitHub MCP and use labels from [docs/ISSUE_REFINEMENTS.md](docs/ISSUE_REFINEMENTS.md) / [issue-refinement-triage](.cursor/skills/issue-refinement-triage/SKILL.md).
+1. **Issue:** From conversation (e.g. "issue #5") or search — identify the main issue #M. If none exists, create one via GitHub MCP and use labels from [issue-refinement-triage](.cursor/skills/issue-refinement-triage/SKILL.md).
 2. **Scope:** If the change is small or not splittable → single PR. If large and decomposable → create sub-issues S1…Sn, then multiple PRs (see [reference.md](reference.md) for heuristics).
 
 ## Single PR workflow
@@ -36,7 +36,7 @@ Use `call_mcp_tool` with `server: "user-github"`. Typical tools and intent:
 | ---------------------------------- | ------------------------------------------------------------------------- |
 | get_me                             | Current user and permissions; infer or confirm owner/repo                 |
 | search_issues                      | Find existing issue by number, title, or labels; avoid duplicate creation |
-| create_issue (or equivalent)       | Create main or sub-issue when missing; use ISSUE_REFINEMENTS labels       |
+| create_issue (or equivalent)       | Create main or sub-issue when missing; use issue-refinement-triage labels |
 | create_pull_request                | Create PR from branch; use repo PR template if present                    |
 | list_issue_types                   | Optional; use for orgs that use issue types                               |
 

--- a/.cursor/skills/skill-hygiene/SKILL.md
+++ b/.cursor/skills/skill-hygiene/SKILL.md
@@ -9,8 +9,8 @@ When updating a skill (see `.cursor/rules/skill-maintenance.mdc` for when to do 
 
 ## issue-refinement-triage
 
-- Issue block template still matches `docs/ISSUE_REFINEMENTS.md`.
-- Label table matches the "Label usage summary" in ISSUE_REFINEMENTS (same labels and "Use for" text).
+- Issue block template still matches [issue-refinement-triage/SKILL.md](issue-refinement-triage/SKILL.md).
+- Label table matches the label table in that skill (same labels and "Use for" text).
 - Workflow steps still reflect how open/closed issues and "My comments" are used.
 
 ## wxt-svelte-extension

--- a/src/lib/components/Measurements.svelte
+++ b/src/lib/components/Measurements.svelte
@@ -1,86 +1,80 @@
 <script lang="ts">
-	import { elementInspector } from "@/lib/core/ElementInspector";
-	import {
-		MetaDataStore,
-		TrackersStore,
-		UIStore,
-	} from "@/lib/store/index.svelte";
+  import { elementInspector } from "@/lib/core/ElementInspector";
+  import {
+    MetaDataStore,
+    TrackersStore,
+    UIStore,
+  } from "@/lib/store/index.svelte";
 
-	interface RulerProps {
-		gridSize?: number;
-		color?: string;
-		zIndex?: number;
-	}
+  interface RulerProps {
+    gridSize?: number;
+    color?: string;
+    zIndex?: number;
+  }
 
-	let {
-		gridSize = 8,
-		color = "#3b82f6",
-		zIndex = 9998,
-	}: RulerProps = $props();
+  let { gridSize = 8, color = "#3b82f6", zIndex = 9998 }: RulerProps = $props();
 
-	const metadataStore = getContext<MetaDataStore>("metadataStore");
-	const trackersStore = getContext<TrackersStore>("trackersStore");
-	const uiStore = getContext<UIStore>("uiStore");
+  const metadataStore = getContext<MetaDataStore>("metadataStore");
+  const trackersStore = getContext<TrackersStore>("trackersStore");
+  const uiStore = getContext<UIStore>("uiStore");
 
-	let isDragging = $state(false);
-	let measurementStart = $state<{ x: number; y: number } | null>(
-		null,
-	);
-	let measurementEnd = $state<{ x: number; y: number } | null>(null);
-	let measurements = $state<
-		Array<{
-			id: string;
-			start: { x: number; y: number };
-			end: { x: number; y: number };
-			distance: number;
-			angle: number;
-		}>
-	>([]);
+  let isDragging = $state(false);
+  let measurementStart = $state<{ x: number; y: number } | null>(null);
+  let measurementEnd = $state<{ x: number; y: number } | null>(null);
+  let measurements = $state<
+    Array<{
+      id: string;
+      start: { x: number; y: number };
+      end: { x: number; y: number };
+      distance: number;
+      angle: number;
+    }>
+  >([]);
 
-	const mouse = metadataStore.mouse;
-	const svg = uiStore.svg;
+  const mouse = metadataStore.mouse;
+  const svg = uiStore.svg;
 </script>
 
 {#if uiStore.isActive}
-	<defs>
-		<marker
-			id="arrowhead"
-			markerWidth="10"
-			markerHeight="7"
-			refX="9"
-			refY="3.5"
-			orient="auto"
-		>
-			<polygon points="0 0, 10 3.5, 0 7" fill={color} />
-		</marker>
+  <defs>
+    <marker
+      id="arrowhead"
+      markerWidth="10"
+      markerHeight="7"
+      refX="9"
+      refY="3.5"
+      orient="auto"
+    >
+      <polygon points="0 0, 10 3.5, 0 7" fill={color} />
+    </marker>
 
-		<pattern
-			id="grid"
-			width={gridSize}
-			height={gridSize}
-			patternUnits="userSpaceOnUse"
-		>
-			<path
-				d="M {gridSize} 0 L 0 0 0 {gridSize}"
-				fill="none"
-				stroke="#e5e7eb"
-				stroke-width="0.5"
-				opacity="0.3"
-			/>
-		</pattern>
-	</defs>
+    <pattern
+      id="grid"
+      width={gridSize}
+      height={gridSize}
+      patternUnits="userSpaceOnUse"
+    >
+      <path
+        d="M {gridSize} 0 L 0 0 0 {gridSize}"
+        fill="none"
+        stroke="#e5e7eb"
+        stroke-width="0.5"
+        opacity="0.3"
+      />
+    </pattern>
+  </defs>
 
-	{#if uiStore.svg.showGrid}
-		<rect
-			class="anim"
-			width="100%"
-			height="100%"
-			fill="url(#grid)"
-			style={`--x: ${metadataStore.mouse.x}; --y:${metadataStore.mouse.y}`}
-		/>
-	{/if}
+  {#if uiStore.svg.showGrid}
+    <rect
+      class="anim"
+      width="100%"
+      height="100%"
+      fill="url(#grid)"
+      style={`--x: ${metadataStore.mouse.x}; --y:${metadataStore.mouse.y}`}
+    />
+  {/if}
 
-	<!-- {#if showMeasurements}
+  <!-- {#if showMeasurements}
 		{#each getTrackerDistances() as distance}
 			<g class="tracker-distance">
 				<line
@@ -112,7 +106,7 @@
 {/if}
 
 <style>
-	/* .anim {
+  /* .anim {
 		--x: 0;
 		--y: 0;
 		--sin-x: sin(var(--x));
@@ -120,61 +114,61 @@
 		transition: transform 0.5s cubic-bezier(0.6, -0.28, 0.735, 0.045);
 		transform: scale(1) skewX(calc(--cos-y * 180deg)) 
 	                      skewY(calc(--sin-x * 3600deg)); */
-	/* animation: glitch-loop-1 0.5s infinite cubic-bezier(0.68, -0.55, 0.265, 1.55) alternate-reverse; */
-	/* transform-origin: center; */
-	/* } */
+  /* animation: glitch-loop-1 0.5s infinite cubic-bezier(0.68, -0.55, 0.265, 1.55) alternate-reverse; */
+  /* transform-origin: center; */
+  /* } */
 
-	@keyframes glitch-loop-1 {
-		0% {
-			transform: scale(1) skewX(0deg) skewY(60deg);
-		}
-		25% {
-			transform: scale(1) skewX(60deg) skewY(-60deg);
-		}
-		50% {
-			transform: scale(1) skewX(-60deg) skewY(60deg);
-		}
-		75% {
-			transform: scale(1) skewX(60deg) skewY(-60deg);
-		}
-		100% {
-			transform: scale(1) skewX(0deg) skewY(60deg);
-		}
-	}
+  @keyframes glitch-loop-1 {
+    0% {
+      transform: scale(1) skewX(0deg) skewY(60deg);
+    }
+    25% {
+      transform: scale(1) skewX(60deg) skewY(-60deg);
+    }
+    50% {
+      transform: scale(1) skewX(-60deg) skewY(60deg);
+    }
+    75% {
+      transform: scale(1) skewX(60deg) skewY(-60deg);
+    }
+    100% {
+      transform: scale(1) skewX(0deg) skewY(60deg);
+    }
+  }
 
-	@keyframes glitch-loop-2 {
-		0% {
-			transform: scale(1) skewX(0deg);
-		}
-		25% {
-			transform: scale(1) skewX(90deg);
-		}
-		50% {
-			transform: scale(1) skewX(-90deg);
-		}
-		75% {
-			transform: scale(1) skewX(90deg);
-		}
-		100% {
-			transform: scale(1) skewX(0deg);
-		}
-	}
+  @keyframes glitch-loop-2 {
+    0% {
+      transform: scale(1) skewX(0deg);
+    }
+    25% {
+      transform: scale(1) skewX(90deg);
+    }
+    50% {
+      transform: scale(1) skewX(-90deg);
+    }
+    75% {
+      transform: scale(1) skewX(90deg);
+    }
+    100% {
+      transform: scale(1) skewX(0deg);
+    }
+  }
 
-	@keyframes glitch-loop-3 {
-		0% {
-			transform: scale(1) skewY(0deg);
-		}
-		25% {
-			transform: scale(1) skewY(90deg);
-		}
-		50% {
-			transform: scale(1) skewY(-90deg);
-		}
-		75% {
-			transform: scale(1) skewY(90deg);
-		}
-		100% {
-			transform: scale(1) skewY(0deg);
-		}
-	}
+  @keyframes glitch-loop-3 {
+    0% {
+      transform: scale(1) skewY(0deg);
+    }
+    25% {
+      transform: scale(1) skewY(90deg);
+    }
+    50% {
+      transform: scale(1) skewY(-90deg);
+    }
+    75% {
+      transform: scale(1) skewY(90deg);
+    }
+    100% {
+      transform: scale(1) skewY(0deg);
+    }
+  }
 </style>

--- a/src/lib/components/Ruler.svelte
+++ b/src/lib/components/Ruler.svelte
@@ -1,251 +1,199 @@
 <script lang="ts">
-	import { MetaDataStore, UIStore } from "@/lib/store/index.svelte";
-	import { Spring } from "svelte/motion";
+  import { MetaDataStore, UIStore } from "@/lib/store/index.svelte";
+  import { Spring } from "svelte/motion";
 
-	let coords = new Spring({ x: 0, y: 0 }, {
-		stiffness: 0.125,
-		damping: 0.675,
-	});
+  let coords = new Spring(
+    { x: 0, y: 0 },
+    {
+      stiffness: 0.125,
+      damping: 0.675,
+    }
+  );
 
-	let step = $state(50);
-	let minorStep = $state(10);
+  let step = $state(50);
+  let minorStep = $state(10);
 
-	const metadataStore = getContext<MetaDataStore>("metadataStore");
-	const uiStore = getContext<UIStore>("uiStore");
+  const metadataStore = getContext<MetaDataStore>("metadataStore");
+  const uiStore = getContext<UIStore>("uiStore");
 
-	$effect.pre(() => {
-		coords.target = {
-			x: metadataStore.mouse.x,
-			y: metadataStore.mouse.y,
-		};
-	});
+  $effect.pre(() => {
+    coords.target = {
+      x: metadataStore.mouse.x,
+      y: metadataStore.mouse.y,
+    };
+  });
 
-	let mouseX = $derived(coords.current.x);
-	let mouseY = $derived(coords.current.y);
-	let xAxisLength = $derived(metadataStore.window.innerWidth);
-	let yAxisLength = $derived(metadataStore.window.innerHeight);
+  let mouseX = $derived(coords.current.x);
+  let mouseY = $derived(coords.current.y);
+  let xAxisLength = $derived(metadataStore.window.innerWidth);
+  let yAxisLength = $derived(metadataStore.window.innerHeight);
 </script>
 
 <!-- Dynamic coordinate axes from mouse position -->
 {#if uiStore.svg.showRuler}
-	<g filter="url(#invertedOutline)">
-		<!-- Main axes -->
-		<g stroke="#fff" stroke-width="2">
-			<!-- X-axis (horizontal) - extends left and right from mouse -->
-			<line
-				x1={0}
-				y1={mouseY}
-				x2={xAxisLength}
-				y2={mouseY}
-			/>
-			<!-- Y-axis (vertical) - extends up and down from mouse -->
-			<line
-				x1={mouseX}
-				y1={0}
-				x2={mouseX}
-				y2={yAxisLength}
-			/>
-		</g>
+  <g filter="url(#invertedOutline)">
+    <!-- Main axes -->
+    <g stroke="#fff" stroke-width="2">
+      <!-- X-axis (horizontal) - extends left and right from mouse -->
+      <line x1={0} y1={mouseY} x2={xAxisLength} y2={mouseY} />
+      <!-- Y-axis (vertical) - extends up and down from mouse -->
+      <line x1={mouseX} y1={0} x2={mouseX} y2={yAxisLength} />
+    </g>
 
-		<!-- X-axis ticks and labels -->
-		<g>
-			<!-- Positive X-axis ticks -->
-			<g stroke="#fff" stroke-width="1">
-				{#each Array(Math.floor(xAxisLength / step) + 1) as _, i}
-					{#if i > 0}
-						{@const x = mouseX + i * step}
-						{#if x <= xAxisLength}
-							<line
-								x1={x}
-								y1={mouseY - 5}
-								x2={x}
-								y2={mouseY + 5}
-							/>
-						{/if}
-					{/if}
-				{/each}
-			</g>
+    <!-- X-axis ticks and labels -->
+    <g>
+      <!-- Positive X-axis ticks -->
+      <g stroke="#fff" stroke-width="1">
+        {#each Array(Math.floor(xAxisLength / step) + 1) as _, i}
+          {#if i > 0}
+            {@const x = mouseX + i * step}
+            {#if x <= xAxisLength}
+              <line x1={x} y1={mouseY - 5} x2={x} y2={mouseY + 5} />
+            {/if}
+          {/if}
+        {/each}
+      </g>
 
-			<!-- Negative X-axis ticks -->
-			<g stroke="#fff" stroke-width="1">
-				{#each Array(Math.floor(xAxisLength / step) + 1) as _, i}
-					{#if i > 0}
-						{@const x = mouseX - i * step}
-						{#if x >= 0}
-							<line
-								x1={x}
-								y1={mouseY - 5}
-								x2={x}
-								y2={mouseY + 5}
-							/>
-						{/if}
-					{/if}
-				{/each}
-			</g>
+      <!-- Negative X-axis ticks -->
+      <g stroke="#fff" stroke-width="1">
+        {#each Array(Math.floor(xAxisLength / step) + 1) as _, i}
+          {#if i > 0}
+            {@const x = mouseX - i * step}
+            {#if x >= 0}
+              <line x1={x} y1={mouseY - 5} x2={x} y2={mouseY + 5} />
+            {/if}
+          {/if}
+        {/each}
+      </g>
 
-			<!-- X-axis minor ticks -->
-			<g stroke="#fff" stroke-width="0.5">
-				{#each Array(Math.floor(xAxisLength / minorStep) + 1) as _, i}
-					{#if i > 0 && (i * minorStep) % step !== 0}
-						{@const xPos = mouseX + i * minorStep}
-						{@const xNeg = mouseX - i * minorStep}
-						{#if xPos <= xAxisLength}
-							<line
-								x1={xPos}
-								y1={mouseY - 3}
-								x2={xPos}
-								y2={mouseY + 3}
-							/>
-						{/if}
-						{#if xNeg >= 0}
-							<line
-								x1={xNeg}
-								y1={mouseY - 3}
-								x2={xNeg}
-								y2={mouseY + 3}
-							/>
-						{/if}
-					{/if}
-				{/each}
-			</g>
+      <!-- X-axis minor ticks -->
+      <g stroke="#fff" stroke-width="0.5">
+        {#each Array(Math.floor(xAxisLength / minorStep) + 1) as _, i}
+          {#if i > 0 && (i * minorStep) % step !== 0}
+            {@const xPos = mouseX + i * minorStep}
+            {@const xNeg = mouseX - i * minorStep}
+            {#if xPos <= xAxisLength}
+              <line x1={xPos} y1={mouseY - 3} x2={xPos} y2={mouseY + 3} />
+            {/if}
+            {#if xNeg >= 0}
+              <line x1={xNeg} y1={mouseY - 3} x2={xNeg} y2={mouseY + 3} />
+            {/if}
+          {/if}
+        {/each}
+      </g>
 
-			<!-- X-axis labels -->
-			<g
-				font-family="Inter, sans-serif"
-				font-size="10"
-				fill="#fff"
-				text-anchor="middle"
-			>
-				{#each Array(Math.floor(xAxisLength / step) + 1) as _, i}
-					{#if i > 0}
-						{@const xPos = mouseX + i * step}
-						{@const xNeg = mouseX - i * step}
-						{@const value = i * step}
-						{#if 				xPos <= xAxisLength &&
-					mouseY + 15 <= yAxisLength}
-							<text x={xPos} y={mouseY + 15}>{value}</text>
-						{/if}
-						{#if xNeg >= 0 && mouseY + 15 <= yAxisLength}
-							<text x={xNeg} y={mouseY + 15}>-{value}</text>
-						{/if}
-					{/if}
-				{/each}
-				<!-- Origin label -->
-				{#if mouseY + 15 <= yAxisLength}
-					<text x={mouseX} y={mouseY + 15}>0</text>
-				{/if}
-			</g>
-		</g>
+      <!-- X-axis labels -->
+      <g
+        font-family="Inter, sans-serif"
+        font-size="10"
+        fill="#fff"
+        text-anchor="middle"
+      >
+        {#each Array(Math.floor(xAxisLength / step) + 1) as _, i}
+          {#if i > 0}
+            {@const xPos = mouseX + i * step}
+            {@const xNeg = mouseX - i * step}
+            {@const value = i * step}
+            {#if xPos <= xAxisLength && mouseY + 15 <= yAxisLength}
+              <text x={xPos} y={mouseY + 15}>{value}</text>
+            {/if}
+            {#if xNeg >= 0 && mouseY + 15 <= yAxisLength}
+              <text x={xNeg} y={mouseY + 15}>-{value}</text>
+            {/if}
+          {/if}
+        {/each}
+        <!-- Origin label -->
+        {#if mouseY + 15 <= yAxisLength}
+          <text x={mouseX} y={mouseY + 15}>0</text>
+        {/if}
+      </g>
+    </g>
 
-		<!-- Y-axis ticks and labels -->
-		<g>
-			<!-- Positive Y-axis ticks (upward) -->
-			<g stroke="#fff" stroke-width="1">
-				{#each Array(Math.floor(yAxisLength / step) + 1) as _, i}
-					{#if i > 0}
-						{@const y = mouseY - i * step}
-						{#if y >= 0}
-							<line
-								x1={mouseX - 5}
-								y1={y}
-								x2={mouseX + 5}
-								y2={y}
-							/>
-						{/if}
-					{/if}
-				{/each}
-			</g>
+    <!-- Y-axis ticks and labels -->
+    <g>
+      <!-- Positive Y-axis ticks (upward) -->
+      <g stroke="#fff" stroke-width="1">
+        {#each Array(Math.floor(yAxisLength / step) + 1) as _, i}
+          {#if i > 0}
+            {@const y = mouseY - i * step}
+            {#if y >= 0}
+              <line x1={mouseX - 5} y1={y} x2={mouseX + 5} y2={y} />
+            {/if}
+          {/if}
+        {/each}
+      </g>
 
-			<!-- Negative Y-axis ticks (downward) -->
-			<g stroke="#fff" stroke-width="1">
-				{#each Array(Math.floor(yAxisLength / step) + 1) as _, i}
-					{#if i > 0}
-						{@const y = mouseY + i * step}
-						{#if y <= yAxisLength}
-							<line
-								x1={mouseX - 5}
-								y1={y}
-								x2={mouseX + 5}
-								y2={y}
-							/>
-						{/if}
-					{/if}
-				{/each}
-			</g>
+      <!-- Negative Y-axis ticks (downward) -->
+      <g stroke="#fff" stroke-width="1">
+        {#each Array(Math.floor(yAxisLength / step) + 1) as _, i}
+          {#if i > 0}
+            {@const y = mouseY + i * step}
+            {#if y <= yAxisLength}
+              <line x1={mouseX - 5} y1={y} x2={mouseX + 5} y2={y} />
+            {/if}
+          {/if}
+        {/each}
+      </g>
 
-			<!-- Y-axis minor ticks -->
-			<g stroke="#fff" stroke-width="0.5">
-				{#each Array(Math.floor(yAxisLength / minorStep) + 1) as _, i}
-					{#if i > 0 && (i * minorStep) % step !== 0}
-						{@const yPos = mouseY - i * minorStep}
-						{@const yNeg = mouseY + i * minorStep}
-						{#if yPos >= 0}
-							<line
-								x1={mouseX - 3}
-								y1={yPos}
-								x2={mouseX + 3}
-								y2={yPos}
-							/>
-						{/if}
-						{#if yNeg <= yAxisLength}
-							<line
-								x1={mouseX - 3}
-								y1={yNeg}
-								x2={mouseX + 3}
-								y2={yNeg}
-							/>
-						{/if}
-					{/if}
-				{/each}
-			</g>
+      <!-- Y-axis minor ticks -->
+      <g stroke="#fff" stroke-width="0.5">
+        {#each Array(Math.floor(yAxisLength / minorStep) + 1) as _, i}
+          {#if i > 0 && (i * minorStep) % step !== 0}
+            {@const yPos = mouseY - i * minorStep}
+            {@const yNeg = mouseY + i * minorStep}
+            {#if yPos >= 0}
+              <line x1={mouseX - 3} y1={yPos} x2={mouseX + 3} y2={yPos} />
+            {/if}
+            {#if yNeg <= yAxisLength}
+              <line x1={mouseX - 3} y1={yNeg} x2={mouseX + 3} y2={yNeg} />
+            {/if}
+          {/if}
+        {/each}
+      </g>
 
-			<!-- Y-axis labels -->
-			<g
-				font-family="Inter, sans-serif"
-				font-size="10"
-				fill="#fff"
-				text-anchor="end"
-			>
-				{#each Array(Math.floor(yAxisLength / step) + 1) as _, i}
-					{#if i > 0}
-						{@const yPos = mouseY - i * step}
-						{@const yNeg = mouseY + i * step}
-						{@const value = i * step}
-						{#if yPos >= 0 && mouseX - 10 >= 0}
-							<text x={mouseX - 10} y={yPos + 4}>{value}</text>
-						{/if}
-						{#if yNeg <= yAxisLength && mouseX - 10 >= 0}
-							<text x={mouseX - 10} y={yNeg + 4}>-{value}</text>
-						{/if}
-					{/if}
-				{/each}
-			</g>
-		</g>
+      <!-- Y-axis labels -->
+      <g
+        font-family="Inter, sans-serif"
+        font-size="10"
+        fill="#fff"
+        text-anchor="end"
+      >
+        {#each Array(Math.floor(yAxisLength / step) + 1) as _, i}
+          {#if i > 0}
+            {@const yPos = mouseY - i * step}
+            {@const yNeg = mouseY + i * step}
+            {@const value = i * step}
+            {#if yPos >= 0 && mouseX - 10 >= 0}
+              <text x={mouseX - 10} y={yPos + 4}>{value}</text>
+            {/if}
+            {#if yNeg <= yAxisLength && mouseX - 10 >= 0}
+              <text x={mouseX - 10} y={yNeg + 4}>-{value}</text>
+            {/if}
+          {/if}
+        {/each}
+      </g>
+    </g>
 
-		<!-- Axis labels -->
-		<g
-			font-family="Inter, sans-serif"
-			font-size="12"
-			font-weight="bold"
-			fill="#fff"
-		>
-			{#if true}
-				{@const 			rightLabelX = Math.min(
-				xAxisLength - 20,
-				mouseX + xAxisLength - 10,
-			)}
-				{@const upLabelY = Math.max(15, mouseY - yAxisLength + 10)}
-				{#if rightLabelX > mouseX + 20}
-					<text x={rightLabelX} y={mouseY - 8} text-anchor="middle">
-						X
-					</text>
-				{/if}
-				{#if upLabelY < mouseY - 20}
-					<text x={mouseX + 12} y={upLabelY} text-anchor="middle">
-						Y
-					</text>
-				{/if}
-			{/if}
-		</g>
-	</g>
+    <!-- Axis labels -->
+    <g
+      font-family="Inter, sans-serif"
+      font-size="12"
+      font-weight="bold"
+      fill="#fff"
+    >
+      {#if true}
+        {@const rightLabelX = Math.min(
+          xAxisLength - 20,
+          mouseX + xAxisLength - 10
+        )}
+        {@const upLabelY = Math.max(15, mouseY - yAxisLength + 10)}
+        {#if rightLabelX > mouseX + 20}
+          <text x={rightLabelX} y={mouseY - 8} text-anchor="middle"> X </text>
+        {/if}
+        {#if upLabelY < mouseY - 20}
+          <text x={mouseX + 12} y={upLabelY} text-anchor="middle"> Y </text>
+        {/if}
+      {/if}
+    </g>
+  </g>
 {/if}

--- a/src/lib/components/SelectorManager.svelte
+++ b/src/lib/components/SelectorManager.svelte
@@ -1,28 +1,22 @@
 <script lang="ts">
-	import { TrackersStore, UIStore } from "@/lib/store/index.svelte";
-	import Tracker from "./Tracker.svelte";
+  import { TrackersStore, UIStore } from "@/lib/store/index.svelte";
+  import Tracker from "./Tracker.svelte";
 
-	interface SelectorManagerProps {
-		enabled?: boolean;
-		maxTrackers?: number;
-		autoCleanup?: boolean;
-	}
+  interface SelectorManagerProps {
+    enabled?: boolean;
+    maxTrackers?: number;
+    autoCleanup?: boolean;
+  }
 
-	let {
-		enabled = true,
-		autoCleanup = true,
-	}: SelectorManagerProps = $props();
+  let { enabled = true, autoCleanup = true }: SelectorManagerProps = $props();
 
-	const trackersStore = getContext<TrackersStore>("trackersStore");
-	const uiStore = getContext<UIStore>("uiStore");
+  const trackersStore = getContext<TrackersStore>("trackersStore");
+  const uiStore = getContext<UIStore>("uiStore");
 </script>
 
 {#if enabled && uiStore.isActive}
-	{#each trackersStore.lockedTrackers as tracker (tracker.id)}
-		<Tracker
-			trackerId={tracker.id}
-			zIndex={1000000002}
-		/>
-	{/each}
-	<Tracker zIndex={1000000003} />
+  {#each trackersStore.lockedTrackers as tracker (tracker.id)}
+    <Tracker trackerId={tracker.id} zIndex={1000000002} />
+  {/each}
+  <Tracker zIndex={1000000003} />
 {/if}

--- a/src/lib/components/Switch.svelte
+++ b/src/lib/components/Switch.svelte
@@ -1,54 +1,54 @@
 <script lang="ts">
-	import { generateId } from "@/lib/utils/useId";
-	import { Switch } from "@ark-ui/svelte/switch";
+  import { generateId } from "@/lib/utils/useId";
+  import { Switch } from "@ark-ui/svelte/switch";
 
-	interface Props {
-		id?: string;
-		checked?: boolean;
-		labelText: string;
-		disabled?: boolean;
-		class?: string;
-		style?: string;
-		onCheckedChange?: (details: { checked: boolean }) => void;
-	}
+  interface Props {
+    id?: string;
+    checked?: boolean;
+    labelText: string;
+    disabled?: boolean;
+    class?: string;
+    style?: string;
+    onCheckedChange?: (details: { checked: boolean }) => void;
+  }
 
-	const defaultSwitchId = generateId("switch");
+  const defaultSwitchId = generateId("switch");
 
-	let {
-		id: idProp,
-		checked = $bindable(false),
-		labelText,
-		disabled = false,
-		class: classes = "",
-		style = "",
-		...restProps
-	}: Props = $props();
+  let {
+    id: idProp,
+    checked = $bindable(false),
+    labelText,
+    disabled = false,
+    class: classes = "",
+    style = "",
+    ...restProps
+  }: Props = $props();
 
-	const id = $derived(idProp ?? defaultSwitchId);
+  const id = $derived(idProp ?? defaultSwitchId);
 
-	function handleCheckedChange(details: { checked: boolean }) {
-		checked = details.checked;
-	}
+  function handleCheckedChange(details: { checked: boolean }) {
+    checked = details.checked;
+  }
 </script>
 
 <Switch.Root
-	{id}
-	{checked}
-	{disabled}
-	onCheckedChange={handleCheckedChange}
-	class="flex justify-between items-center gap-3 w-full {classes}"
-	{style}
-	{...restProps}
+  {id}
+  {checked}
+  {disabled}
+  onCheckedChange={handleCheckedChange}
+  class="flex justify-between items-center gap-3 w-full {classes}"
+  {style}
+  {...restProps}
 >
-	<Switch.Label class="cursor-inherit flex-1 text-start">
-		{labelText}
-	</Switch.Label>
-	<Switch.Control
-		class="h-full p-0.5 w-12 h-6 focus-visible:ring-white focus-visible:ring-offset data-[state=checked]:bg-lime-700 data-[state=unchecked]:bg-neutral-700 data-[state=unchecked]:shadow-inner dark:data-[state=checked]:bg-white focus-visible:outline-hidden inline-flex cursor-pointer items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-	>
-		<Switch.Thumb
-			class="bg-white h-4 w-4 data-[state=unchecked]:shadow-md pointer-events-none block rounded-full transition-transform data-[state=checked]:translate-x-6 data-[state=unchecked]:translate-x-0 dark:border dark:data-[state=unchecked]:border"
-		/>
-	</Switch.Control>
-	<Switch.HiddenInput />
+  <Switch.Label class="cursor-inherit flex-1 text-start">
+    {labelText}
+  </Switch.Label>
+  <Switch.Control
+    class="h-full p-0.5 w-12 h-6 focus-visible:ring-white focus-visible:ring-offset data-[state=checked]:bg-lime-700 data-[state=unchecked]:bg-neutral-700 data-[state=unchecked]:shadow-inner dark:data-[state=checked]:bg-white focus-visible:outline-hidden inline-flex cursor-pointer items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+  >
+    <Switch.Thumb
+      class="bg-white h-4 w-4 data-[state=unchecked]:shadow-md pointer-events-none block rounded-full transition-transform data-[state=checked]:translate-x-6 data-[state=unchecked]:translate-x-0 dark:border dark:data-[state=unchecked]:border"
+    />
+  </Switch.Control>
+  <Switch.HiddenInput />
 </Switch.Root>

--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -1,41 +1,37 @@
 <script lang="ts">
-	import {
-		createToaster,
-		Toast,
-		Toaster,
-	} from "@ark-ui/svelte/toast";
-	import { X } from "@lucide/svelte";
+  import { createToaster, Toast, Toaster } from "@ark-ui/svelte/toast";
+  import { X } from "@lucide/svelte";
 
-	const toaster = createToaster({
-		placement: "bottom-end",
-		overlap: true,
-		gap: 24,
-	});
+  const toaster = createToaster({
+    placement: "bottom-end",
+    overlap: true,
+    gap: 24,
+  });
 
-	function addToast() {
-		toaster.create({
-			title: "Toast Title",
-			description: "Toast Description",
-			type: "info",
-		});
-	}
+  function addToast() {
+    toaster.create({
+      title: "Toast Title",
+      description: "Toast Description",
+      type: "info",
+    });
+  }
 
-	onMount(addToast);
+  onMount(addToast);
 </script>
 
 {#if import.meta.env.DEV}
-	<div class="bg-white pointer-events-initial px-4">
-		<button type="button" onclick={addToast}>Add Toast</button>
-		<Toaster {toaster}>
-			{#snippet children(toast)}
-				<Toast.Root class="bg-white">
-					<Toast.Title>{toast().title}</Toast.Title>
-					<Toast.Description>{toast().description}</Toast.Description>
-					<Toast.CloseTrigger>
-						<X />
-					</Toast.CloseTrigger>
-				</Toast.Root>
-			{/snippet}
-		</Toaster>
-	</div>
+  <div class="bg-white pointer-events-initial px-4">
+    <button type="button" onclick={addToast}>Add Toast</button>
+    <Toaster {toaster}>
+      {#snippet children(toast)}
+        <Toast.Root class="bg-white">
+          <Toast.Title>{toast().title}</Toast.Title>
+          <Toast.Description>{toast().description}</Toast.Description>
+          <Toast.CloseTrigger>
+            <X />
+          </Toast.CloseTrigger>
+        </Toast.Root>
+      {/snippet}
+    </Toaster>
+  </div>
 {/if}

--- a/src/lib/components/ToolbarAction.svelte
+++ b/src/lib/components/ToolbarAction.svelte
@@ -1,51 +1,51 @@
 <script lang="ts">
-	import Tooltip from "@/lib/components/Tooltip.svelte";
-	import { Toggle } from "@ark-ui/svelte/toggle";
-	import type { ComponentProps } from "svelte";
+  import Tooltip from "@/lib/components/Tooltip.svelte";
+  import { Toggle } from "@ark-ui/svelte/toggle";
+  import type { ComponentProps } from "svelte";
 
-	interface Props {
-		children: import("svelte").Snippet<[{ pressed: boolean }]>;
-		disabled?: boolean;
-		label?: string;
-		onPressedChange?: (pressed: boolean) => void;
-		pressed?: boolean;
-		shortcut?: string;
-		class?: string;
-	}
+  interface Props {
+    children: import("svelte").Snippet<[{ pressed: boolean }]>;
+    disabled?: boolean;
+    label?: string;
+    onPressedChange?: (pressed: boolean) => void;
+    pressed?: boolean;
+    shortcut?: string;
+    class?: string;
+  }
 
-	let {
-		children,
-		disabled = false,
-		label,
-		onPressedChange,
-		pressed = $bindable(false),
-		shortcut,
-		class: className = "",
-		...restProps
-	}: Props = $props();
+  let {
+    children,
+    disabled = false,
+    label,
+    onPressedChange,
+    pressed = $bindable(false),
+    shortcut,
+    class: className = "",
+    ...restProps
+  }: Props = $props();
 
-	function handlePressedChange(newPressed: boolean) {
-		pressed = newPressed;
-		onPressedChange?.(newPressed);
-	}
+  function handlePressedChange(newPressed: boolean) {
+    pressed = newPressed;
+    onPressedChange?.(newPressed);
+  }
 </script>
 
 <Tooltip {label}>
-	<Toggle.Root
-		aria-label={disabled ? "Coming soon..." : (label ?? "")}
-		{disabled}
-		{pressed}
-		onPressedChange={handlePressedChange}
-		class="fade-in size-7 sm:size-10 outline-none rounded-sm data-[state=off]:not-disabled:hover:bg-lime-200 data-[state=off]:not-disabled:hover:text-lime-500 !active:bg-lime-700 !active:text-lime-500 data-[state=on]:bg-lime-700 data-[state=on]:text-white/80 inline-flex items-center justify-center transition-all not-disabled:active:rounded-3xl not-disabled:active:scale-[0.85] {className}"
-		{...restProps}
-	>
-		{@render children?.({ pressed })}
-		{#if shortcut}
-			<kbd
-				class="text-xs not-prose duration-75 absolute translate-y-2 translate-x-2.5 sm:translate-y-3 sm:translate-x-3.5"
-			>
-				{shortcut}
-			</kbd>
-		{/if}
-	</Toggle.Root>
+  <Toggle.Root
+    aria-label={disabled ? "Coming soon..." : (label ?? "")}
+    {disabled}
+    {pressed}
+    onPressedChange={handlePressedChange}
+    class="fade-in size-7 sm:size-10 outline-none rounded-sm data-[state=off]:not-disabled:hover:bg-lime-200 data-[state=off]:not-disabled:hover:text-lime-500 !active:bg-lime-700 !active:text-lime-500 data-[state=on]:bg-lime-700 data-[state=on]:text-white/80 inline-flex items-center justify-center transition-all not-disabled:active:rounded-3xl not-disabled:active:scale-[0.85] {className}"
+    {...restProps}
+  >
+    {@render children?.({ pressed })}
+    {#if shortcut}
+      <kbd
+        class="text-xs not-prose duration-75 absolute translate-y-2 translate-x-2.5 sm:translate-y-3 sm:translate-x-3.5"
+      >
+        {shortcut}
+      </kbd>
+    {/if}
+  </Toggle.Root>
 </Tooltip>

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -1,49 +1,48 @@
 <script lang="ts">
-	import { generateId } from "@/lib/utils/useId";
-	import { Tooltip } from "@ark-ui/svelte/tooltip";
-	import { type Snippet } from "svelte";
-	import { fade } from "svelte/transition";
+  import { generateId } from "@/lib/utils/useId";
+  import { Tooltip } from "@ark-ui/svelte/tooltip";
+  import { type Snippet } from "svelte";
+  import { fade } from "svelte/transition";
 
-	interface Props {
-		children: Snippet;
-		label?: string;
-		side?: "top" | "bottom" | "left" | "right";
-		sideOffset?: number;
-	}
+  interface Props {
+    children: Snippet;
+    label?: string;
+    side?: "top" | "bottom" | "left" | "right";
+    sideOffset?: number;
+  }
 
-	let { children, label, side = "top", sideOffset = -2 }: Props =
-		$props();
+  let { children, label, side = "top", sideOffset = -2 }: Props = $props();
 
-	const tooltipId = generateId("tooltip");
+  const tooltipId = generateId("tooltip");
 </script>
 
 <Tooltip.Root
-	id={tooltipId}
-	closeOnClick={false}
-	interactive={false}
-	openDelay={1000}
-	closeDelay={500}
-	positioning={{
-		placement: side,
-		offset: { mainAxis: sideOffset },
-	}}
+  id={tooltipId}
+  closeOnClick={false}
+  interactive={false}
+  openDelay={1000}
+  closeDelay={500}
+  positioning={{
+    placement: side,
+    offset: { mainAxis: sideOffset },
+  }}
 >
-	<Tooltip.Trigger disabled={label === undefined}>
-		{@render children?.()}
-	</Tooltip.Trigger>
-	<Tooltip.Positioner>
-		<Tooltip.Content>
-			{#if label}
-				<p
-					class="border-lime-300 max-w-[35ch] bg-white shadow-lime-600 shadow-sm outline-hidden flex items-center p-3 justify-center border-2 rounded-lg font-medium"
-					transition:fade={{ duration: 75 }}
-				>
-					{label}
-				</p>
-			{/if}
-			<Tooltip.Arrow>
-				<Tooltip.ArrowTip />
-			</Tooltip.Arrow>
-		</Tooltip.Content>
-	</Tooltip.Positioner>
+  <Tooltip.Trigger disabled={label === undefined}>
+    {@render children?.()}
+  </Tooltip.Trigger>
+  <Tooltip.Positioner>
+    <Tooltip.Content>
+      {#if label}
+        <p
+          class="border-lime-300 max-w-[35ch] bg-white shadow-lime-600 shadow-sm outline-hidden flex items-center p-3 justify-center border-2 rounded-lg font-medium"
+          transition:fade={{ duration: 75 }}
+        >
+          {label}
+        </p>
+      {/if}
+      <Tooltip.Arrow>
+        <Tooltip.ArrowTip />
+      </Tooltip.Arrow>
+    </Tooltip.Content>
+  </Tooltip.Positioner>
 </Tooltip.Root>

--- a/src/lib/modules/ExtenstionSettings/App.svelte
+++ b/src/lib/modules/ExtenstionSettings/App.svelte
@@ -1,159 +1,162 @@
 <script lang="ts">
-	import { useAppConfig } from "#imports";
-	import IconOff from "@/assets/icon-off.png";
-	import IconOn from "@/assets/icon.png";
-	import {
-		createMessageHandler,
-		sendMessage,
-	} from "@/lib/core/MessageBus";
-	import { getDomainActive } from "@/lib/storage/amgState";
-	import { Switch } from "@ark-ui/svelte/switch";
-	import { browser } from "wxt/browser";
-	import "./app.css";
-	import { fade } from "svelte/transition";
+  import { useAppConfig } from "#imports";
+  import IconOff from "@/assets/icon-off.png";
+  import IconOn from "@/assets/icon.png";
+  import { createMessageHandler, sendMessage } from "@/lib/core/MessageBus";
+  import { getDomainActive } from "@/lib/storage/amgState";
+  import { Switch } from "@ark-ui/svelte/switch";
+  import { browser } from "wxt/browser";
+  import "./app.css";
+  import { fade } from "svelte/transition";
 
-	const appConfig = useAppConfig();
+  const appConfig = useAppConfig();
 
-	let isLoading = $state(false);
-	let errorMessage = $state("");
-	let successMessage = $state("");
+  let isLoading = $state(false);
+  let errorMessage = $state("");
+  let successMessage = $state("");
 
-	let isActive = $state<boolean>();
+  let isActive = $state<boolean>();
 
-	let domain = "";
+  let domain = "";
 
-	async function mount() {
-		try {
-			analytics.page(location.href);
+  async function mount() {
+    try {
+      analytics.page(location.href);
 
-			let [tab] = await browser.tabs.query({
-				active: true,
-				currentWindow: true,
-			});
+      let [tab] = await browser.tabs.query({
+        active: true,
+        currentWindow: true,
+      });
 
-			if (!tab) {
-				const fallbackTabs = await browser.tabs.query({
-					active: true,
-					currentWindow: true,
-				});
-				[tab] = fallbackTabs;
-			}
+      if (!tab) {
+        const fallbackTabs = await browser.tabs.query({
+          active: true,
+          currentWindow: true,
+        });
+        [tab] = fallbackTabs;
+      }
 
-			if (tab?.url) {
-				const url = new URL(tab.url);
-				domain = url.host;
+      if (tab?.url) {
+        const url = new URL(tab.url);
+        domain = url.host;
 
-				isActive = await getDomainActive(domain);
-			}
+        isActive = await getDomainActive(domain);
+      }
 
-			if (isActive === undefined) {
-				isActive = false;
-			}
-		} catch (error) {
-			errorMessage = "Failed to load inspector state";
-			console.error("Error loading inspector state:", error);
-		}
-	}
+      if (isActive === undefined) {
+        isActive = false;
+      }
+    } catch (error) {
+      errorMessage = "Failed to load inspector state";
+      console.error("Error loading inspector state:", error);
+    }
+  }
 
-	$effect.pre(() => {
-		const unsub = createMessageHandler(
-			"EXTENSION_TOGGLE",
-			(payload: any, message) => {
-				isActive = payload.isActive;
-			},
-		);
+  $effect.pre(() => {
+    const unsub = createMessageHandler(
+      "EXTENSION_TOGGLE",
+      (payload: any, message) => {
+        isActive = payload.isActive;
+      }
+    );
 
-		return unsub;
-	});
+    return unsub;
+  });
 
-	$effect(() => {
-		mount();
-	});
+  $effect(() => {
+    mount();
+  });
 
-	async function toggleActiveContent() {
-		if (isLoading) return;
+  async function toggleActiveContent() {
+    if (isLoading) return;
 
-		isLoading = true;
-		errorMessage = "";
-		successMessage = "";
+    isLoading = true;
+    errorMessage = "";
+    successMessage = "";
 
-		try {
-			await sendMessage("EXTENSION_TOGGLE", {
-				isActive: !isActive,
-				domain,
-				timestamp: Date.now(),
-			});
-		} catch (error) {
-			errorMessage = "Failed to toggle inspector";
-			console.error("Error toggling inspector:", error);
-		} finally {
-			isLoading = false;
-			setTimeout(() => {
-				successMessage = "";
-				errorMessage = "";
-			}, 2000);
-		}
-	}
+    try {
+      await sendMessage("EXTENSION_TOGGLE", {
+        isActive: !isActive,
+        domain,
+        timestamp: Date.now(),
+      });
+    } catch (error) {
+      errorMessage = "Failed to toggle inspector";
+      console.error("Error toggling inspector:", error);
+    } finally {
+      isLoading = false;
+      setTimeout(() => {
+        successMessage = "";
+        errorMessage = "";
+      }, 2000);
+    }
+  }
 </script>
 
 <main class="prose prose-zinc bg-lime-300 p-1">
-	<div class="grid grid-cols-1 rounded-xl gap-y-6 p-4 border-1 border-zinc-800 min-h-36">
-		<h1 class="font-bold text-center mt-0 mb-0 text-4xl">Amgif</h1>
-		{#if isActive !== undefined}
-			<div class="grid grid-row-1 grid-col-1">
-				{#if isActive}
-					<img
-						transition:fade|global={{ duration: 150 }}
-						class="justify-self-center-safe col-span-full row-span-full"
-						src={IconOn}
-						alt="amgiflol on icon"
-						width={156}
-					/>
-				{:else}
-					<img
-						transition:fade|global={{ duration: 150 }}
-						class="justify-self-center-safe col-span-full row-span-full"
-						src={IconOff}
-						alt="amgiflol off icon"
-						width={156}
-					/>
-				{/if}
-			</div>
-			<hr class="mt-0 mb-0 border-zinc-800" />
-			<div class="flex justify-between space-x-3">
-				<Switch.Root
-					id="active"
-					checked={isActive}
-					onCheckedChange={(details) => toggleActiveContent()}
-					class="flex justify-between items-center gap-3 w-full"
-				>
-					<Switch.Label
-						class="font-semibold text-xl flex-1 cursor-pointer"
-					>Active:</Switch.Label>
-					<Switch.Control
-						class="focus-visible:ring-white focus-visible:ring-offset-netural-700 data-[state=checked]:bg-white data-[state=unchecked]:bg-neutral-700 data-[state=unchecked]:shadow-mini-inset dark:data-[state=checked]:bg-white focus-visible:outline-hidden peer inline-flex w-[60px] shrink-0 cursor-pointer items-center rounded-full px-[3px] py-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-					>
-						<Switch.Thumb
-							class="bg-neutral-500 data-[state=unchecked]:shadow-sm dark:border-netural-700/30 dark:bg-white dark:shadow-popover pointer-events-none block size-[26px] shrink-0 rounded-full transition-transform data-[state=checked]:translate-x-6.5 data-[state=unchecked]:translate-x-0 dark:border dark:data-[state=unchecked]:border"
-						/>
-					</Switch.Control>
-					<Switch.HiddenInput />
-				</Switch.Root>
-			</div>
+  <div
+    class="grid grid-cols-1 rounded-xl gap-y-6 p-4 border-1 border-zinc-800 min-h-36"
+  >
+    <h1 class="font-bold text-center mt-0 mb-0 text-4xl">Amgif</h1>
+    {#if isActive !== undefined}
+      <div class="grid grid-row-1 grid-col-1">
+        {#if isActive}
+          <img
+            transition:fade|global={{ duration: 150 }}
+            class="justify-self-center-safe col-span-full row-span-full"
+            src={IconOn}
+            alt="amgiflol on icon"
+            width={156}
+          />
+        {:else}
+          <img
+            transition:fade|global={{ duration: 150 }}
+            class="justify-self-center-safe col-span-full row-span-full"
+            src={IconOff}
+            alt="amgiflol off icon"
+            width={156}
+          />
+        {/if}
+      </div>
+      <hr class="mt-0 mb-0 border-zinc-800" />
+      <div class="flex justify-between space-x-3">
+        <Switch.Root
+          id="active"
+          checked={isActive}
+          onCheckedChange={(details) => toggleActiveContent()}
+          class="flex justify-between items-center gap-3 w-full"
+        >
+          <Switch.Label class="font-semibold text-xl flex-1 cursor-pointer"
+            >Active:</Switch.Label
+          >
+          <Switch.Control
+            class="focus-visible:ring-white focus-visible:ring-offset-netural-700 data-[state=checked]:bg-white data-[state=unchecked]:bg-neutral-700 data-[state=unchecked]:shadow-mini-inset dark:data-[state=checked]:bg-white focus-visible:outline-hidden peer inline-flex w-[60px] shrink-0 cursor-pointer items-center rounded-full px-[3px] py-1 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Switch.Thumb
+              class="bg-neutral-500 data-[state=unchecked]:shadow-sm dark:border-netural-700/30 dark:bg-white dark:shadow-popover pointer-events-none block size-[26px] shrink-0 rounded-full transition-transform data-[state=checked]:translate-x-6.5 data-[state=unchecked]:translate-x-0 dark:border dark:data-[state=unchecked]:border"
+            />
+          </Switch.Control>
+          <Switch.HiddenInput />
+        </Switch.Root>
+      </div>
 
-			{#if errorMessage}
-				<div class="w-full p-3 bg-red-100 border border-red-400 text-red-700 rounded-md">
-					{errorMessage}
-				</div>
-			{/if}
+      {#if errorMessage}
+        <div
+          class="w-full p-3 bg-red-100 border border-red-400 text-red-700 rounded-md"
+        >
+          {errorMessage}
+        </div>
+      {/if}
 
-			{#if successMessage}
-				<div class="w-full p-3 bg-green-100 border border-green-400 text-green-700 rounded-md">
-					{successMessage}
-				</div>
-			{/if}
-		{/if}
+      {#if successMessage}
+        <div
+          class="w-full p-3 bg-green-100 border border-green-400 text-green-700 rounded-md"
+        >
+          {successMessage}
+        </div>
+      {/if}
+    {/if}
 
-		<footer class="text-end">v{appConfig.version}</footer>
-	</div>
+    <footer class="text-end">v{appConfig.version}</footer>
+  </div>
 </main>

--- a/src/lib/modules/SidePanel/index.svelte
+++ b/src/lib/modules/SidePanel/index.svelte
@@ -1,306 +1,248 @@
 <script lang="ts">
-	import { MetaDataStore } from "@/lib/store/MetaDataStore.svelte";
-	import { TrackersStore } from "@/lib/store/TrackersStore.svelte";
-	import { TrackerState } from "@/lib/store/TrackerState.svelte";
-	import { UIStore } from "@/lib/store/UIStore.svelte";
-	import { fly } from "svelte/transition";
+  import { MetaDataStore } from "@/lib/store/MetaDataStore.svelte";
+  import { TrackersStore } from "@/lib/store/TrackersStore.svelte";
+  import { TrackerState } from "@/lib/store/TrackerState.svelte";
+  import { UIStore } from "@/lib/store/UIStore.svelte";
+  import { fly } from "svelte/transition";
 
-	const metadataStore = getContext<MetaDataStore>("metadataStore");
-	const uiStore = getContext<UIStore>("uiStore");
-	const trackersStore = getContext<TrackersStore>("trackersStore");
+  const metadataStore = getContext<MetaDataStore>("metadataStore");
+  const uiStore = getContext<UIStore>("uiStore");
+  const trackersStore = getContext<TrackersStore>("trackersStore");
 
-	let panelInLeftHalfState = $state(false);
+  let panelInLeftHalfState = $state(false);
 
-	$effect.pre(() => {
-		if (
-			trackersStore?.current && !trackersStore.current.isLocked &&
-			uiStore.sidePanel.isVisible &&
-			uiStore.sidePanel.autoMove &&
-			trackersStore.current.target?.bounds
-		) {
-			const { left, right } = trackersStore.current.target.bounds;
+  $effect.pre(() => {
+    if (
+      trackersStore?.current &&
+      !trackersStore.current.isLocked &&
+      uiStore.sidePanel.isVisible &&
+      uiStore.sidePanel.autoMove &&
+      trackersStore.current.target?.bounds
+    ) {
+      const { left, right } = trackersStore.current.target.bounds;
 
-			let boxSize = right - left;
+      let boxSize = right - left;
 
-			const meanX = (left + right) / 2;
-			const halfPointX = metadataStore.window.innerWidth / 2;
+      const meanX = (left + right) / 2;
+      const halfPointX = metadataStore.window.innerWidth / 2;
 
-			if (boxSize > halfPointX) {
-				panelInLeftHalfState =
-					metadataStore.mouse.x > halfPointX;
-			} else {
-				panelInLeftHalfState = meanX >= halfPointX;
-			}
-		}
-	});
+      if (boxSize > halfPointX) {
+        panelInLeftHalfState = metadataStore.mouse.x > halfPointX;
+      } else {
+        panelInLeftHalfState = meanX >= halfPointX;
+      }
+    }
+  });
 
-	function copyToClipboard(text: string) {
-		navigator.clipboard
-			.writeText(text)
-			.then(() => {
-				console.log("Copied to clipboard:", text);
-			})
-			.catch((err) => {
-				console.error("Failed to copy: ", err);
-			});
-	}
+  function copyToClipboard(text: string) {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        console.log("Copied to clipboard:", text);
+      })
+      .catch((err) => {
+        console.error("Failed to copy: ", err);
+      });
+  }
 </script>
 
 {#if trackersStore?.current?.target && uiStore.sidePanel.isVisible}
-	{#if panelInLeftHalfState}
-		{@render SidePanel(trackersStore.current.target, true, -200)}
-	{:else}
-		{@render SidePanel(trackersStore.current.target, false, 200)}
-	{/if}
+  {#if panelInLeftHalfState}
+    {@render SidePanel(trackersStore.current.target, true, -200)}
+  {:else}
+    {@render SidePanel(trackersStore.current.target, false, 200)}
+  {/if}
 {/if}
 
 {#snippet SidePanel(
-	tracker: App.TrackerTargetMetaData,
-	left: boolean,
-	x: number,
+  tracker: App.TrackerTargetMetaData,
+  left: boolean,
+  x: number
 )}
-	<aside
-		class={[
-			"fixed top-0 bg-white border border-zinc-200 rounded-lg shadow-xl translate-y-1/10 h-[80vh] overflow-auto pointer-events-initial",
-			{
-				"left-2": left,
-				"right-2": !left,
-			},
-		]}
-		transition:fly|global={{
-			x,
-			duration: 150,
-		}}
-		style={`width:${uiStore.sidePanel.width}px; z-index: 1000000005;`}
-	>
-		<div class="px-4 pb-4 space-y-4">
-			<header class="border-b bg-white border-zinc-200 pb-3 sticky pt-4">
-				<h2 class="text-lg font-semibold text-zinc-800 m-0">
-					Element Inspector
-				</h2>
-			</header>
+  <aside
+    class={[
+      "fixed top-0 bg-white border border-zinc-200 rounded-lg shadow-xl translate-y-1/10 h-[80vh] overflow-auto pointer-events-initial",
+      {
+        "left-2": left,
+        "right-2": !left,
+      },
+    ]}
+    transition:fly|global={{
+      x,
+      duration: 150,
+    }}
+    style={`width:${uiStore.sidePanel.width}px; z-index: 1000000005;`}
+  >
+    <div class="px-4 pb-4 space-y-4">
+      <header class="border-b bg-white border-zinc-200 pb-3 sticky pt-4">
+        <h2 class="text-lg font-semibold text-zinc-800 m-0">
+          Element Inspector
+        </h2>
+      </header>
 
-			<!-- Element Info -->
-			<section class="space-y-2">
-				<h3 class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0">
-					Element
-				</h3>
-				<div class="space-y-1">
-					<div class="flex items-center justify-between">
-						<span class="text-xs text-zinc-600">Tag:</span>
-						<button
-							class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
-							onclick={() =>
-								copyToClipboard(
-									tracker.properties
-										?.tagName || "",
-								)}
-						>
-							{
-								tracker.properties
-									?.tagName || "N/A"
-							}
-						</button>
-					</div>
-					<div class="flex items-center justify-between">
-						<span class="text-xs text-zinc-600">ID:</span>
-						<button
-							class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
-							onclick={() =>
-								copyToClipboard(
-									tracker.properties?.id ||
-										"",
-								)}
-						>
-							{
-								tracker.properties
-									?.id || "N/A"
-							}
-						</button>
-					</div>
-					<div class="flex items-start justify-between">
-						<span class="text-xs text-zinc-600">Classes:</span>
-						<div class="flex flex-wrap gap-1 justify-end max-w-[200px]">
-							{#each 							tracker.properties
-								?.classes ?? [] as
-								className
-							}
-								<button
-									class="text-xs text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-1 py-0.5 rounded"
-									onclick={() =>
-										copyToClipboard(
-											className,
-										)}
-								>
-									{className}
-								</button>
-							{/each}
-						</div>
-					</div>
-				</div>
-			</section>
+      <!-- Element Info -->
+      <section class="space-y-2">
+        <h3
+          class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0"
+        >
+          Element
+        </h3>
+        <div class="space-y-1">
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-zinc-600">Tag:</span>
+            <button
+              class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
+              onclick={() => copyToClipboard(tracker.properties?.tagName || "")}
+            >
+              {tracker.properties?.tagName || "N/A"}
+            </button>
+          </div>
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-zinc-600">ID:</span>
+            <button
+              class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
+              onclick={() => copyToClipboard(tracker.properties?.id || "")}
+            >
+              {tracker.properties?.id || "N/A"}
+            </button>
+          </div>
+          <div class="flex items-start justify-between">
+            <span class="text-xs text-zinc-600">Classes:</span>
+            <div class="flex flex-wrap gap-1 justify-end max-w-[200px]">
+              {#each tracker.properties?.classes ?? [] as className}
+                <button
+                  class="text-xs text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-1 py-0.5 rounded"
+                  onclick={() => copyToClipboard(className)}
+                >
+                  {className}
+                </button>
+              {/each}
+            </div>
+          </div>
+        </div>
+      </section>
 
-			<!-- Dimensions -->
-			<section class="space-y-2">
-				<h3 class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0">
-					Dimensions
-				</h3>
-				<div class="grid grid-cols-2 gap-2">
-					<div class="flex items-center justify-between col-span-2">
-						<span class="text-xs text-zinc-600">Aspect Ratio:</span>
-						<button
-							class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
-							onclick={() =>
-								copyToClipboard(
-									tracker.properties
-										?.dimensions
-										.aspectRatio || "",
-								)}
-						>
-							{
-								tracker.properties
-									?.dimensions
-									.aspectRatio
-							}
-						</button>
-					</div>
-					<div class="flex items-center justify-between">
-						<span class="text-xs text-zinc-600">Width:</span>
-						<button
-							class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
-							onclick={() =>
-								copyToClipboard(
-									tracker.properties
-										?.dimensions.width
-										.toString() ||
-										"",
-								)}
-						>
-							{
-								tracker.properties
-									?.dimensions.width
-							}px
-						</button>
-					</div>
-					<div class="flex items-center justify-between">
-						<span class="text-xs text-zinc-600">Height:</span>
-						<button
-							class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
-							onclick={() =>
-								copyToClipboard(
-									tracker.properties
-										?.dimensions.height
-										.toString() ||
-										"",
-								)}
-						>
-							{
-								tracker.properties
-									?.dimensions.height
-							}px
-						</button>
-					</div>
+      <!-- Dimensions -->
+      <section class="space-y-2">
+        <h3
+          class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0"
+        >
+          Dimensions
+        </h3>
+        <div class="grid grid-cols-2 gap-2">
+          <div class="flex items-center justify-between col-span-2">
+            <span class="text-xs text-zinc-600">Aspect Ratio:</span>
+            <button
+              class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
+              onclick={() =>
+                copyToClipboard(
+                  tracker.properties?.dimensions.aspectRatio || ""
+                )}
+            >
+              {tracker.properties?.dimensions.aspectRatio}
+            </button>
+          </div>
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-zinc-600">Width:</span>
+            <button
+              class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
+              onclick={() =>
+                copyToClipboard(
+                  tracker.properties?.dimensions.width.toString() || ""
+                )}
+            >
+              {tracker.properties?.dimensions.width}px
+            </button>
+          </div>
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-zinc-600">Height:</span>
+            <button
+              class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
+              onclick={() =>
+                copyToClipboard(
+                  tracker.properties?.dimensions.height.toString() || ""
+                )}
+            >
+              {tracker.properties?.dimensions.height}px
+            </button>
+          </div>
 
-					<div class="flex items-center justify-between">
-						<span class="text-xs text-zinc-600">X:</span>
-						<button
-							class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
-							onclick={() =>
-								copyToClipboard(
-									tracker.properties
-										?.dimensions.x
-										.toString() ||
-										"",
-								)}
-						>
-							{
-								tracker.properties
-									?.dimensions.x
-							}px
-						</button>
-					</div>
-					<div class="flex items-center justify-between">
-						<span class="text-xs text-zinc-600">Y:</span>
-						<button
-							class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
-							onclick={() =>
-								copyToClipboard(
-									tracker.properties
-										?.dimensions.y
-										.toString() ||
-										"",
-								)}
-						>
-							{
-								tracker.properties
-									?.dimensions.y
-							}px
-						</button>
-					</div>
-				</div>
-			</section>
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-zinc-600">X:</span>
+            <button
+              class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
+              onclick={() =>
+                copyToClipboard(
+                  tracker.properties?.dimensions.x.toString() || ""
+                )}
+            >
+              {tracker.properties?.dimensions.x}px
+            </button>
+          </div>
+          <div class="flex items-center justify-between">
+            <span class="text-xs text-zinc-600">Y:</span>
+            <button
+              class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded"
+              onclick={() =>
+                copyToClipboard(
+                  tracker.properties?.dimensions.y.toString() || ""
+                )}
+            >
+              {tracker.properties?.dimensions.y}px
+            </button>
+          </div>
+        </div>
+      </section>
 
-			<!-- Computed Styles -->
-			<section class="space-y-2">
-				<h3 class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0">
-					Computed Styles
-				</h3>
-				<div class="space-y-1">
-					{#each 					Object.entries(
-						tracker.properties?.computedStyles ||
-							{},
-					).sort(([a], [b]) => a.localeCompare(b)) as
-						[key, value]
-					}
-						<div class="flex items-center justify-between">
-							<span class="text-xs text-zinc-600 capitalize">{
-									key.replace(
-										/([A-Z])/g,
-										" $1",
-									).trim()
-								}:</span>
-							<button
-								class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded max-w-[200px] truncate"
-								onclick={() => copyToClipboard(value)}
-								title={value}
-							>
-								{value}
-							</button>
-						</div>
-					{/each}
-				</div>
-			</section>
+      <!-- Computed Styles -->
+      <section class="space-y-2">
+        <h3
+          class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0"
+        >
+          Computed Styles
+        </h3>
+        <div class="space-y-1">
+          {#each Object.entries(tracker.properties?.computedStyles || {}).sort( ([a], [b]) => a.localeCompare(b) ) as [key, value]}
+            <div class="flex items-center justify-between">
+              <span class="text-xs text-zinc-600 capitalize"
+                >{key.replace(/([A-Z])/g, " $1").trim()}:</span
+              >
+              <button
+                class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded max-w-[200px] truncate"
+                onclick={() => copyToClipboard(value)}
+                title={value}
+              >
+                {value}
+              </button>
+            </div>
+          {/each}
+        </div>
+      </section>
 
-			<!-- Attributes -->
-			{#if 			tracker.properties?.attributes &&
-				Object.keys(tracker.properties.attributes).length >
-					0}
-				<section class="space-y-2">
-					<h3 class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0">
-						Attributes
-					</h3>
-					<div class="space-y-1">
-						{#each 					Object.entries(
-						tracker.properties.attributes,
-					).sort(([a], [b]) => a.localeCompare(b)) as
-							[key, value]
-						}
-							<div class="flex items-center justify-between">
-								<span class="text-xs text-zinc-600">{
-										key
-									}:</span>
-								<button
-									class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded max-w-[200px] truncate"
-									onclick={() => copyToClipboard(value)}
-									title={value}
-								>
-									{value}
-								</button>
-							</div>
-						{/each}
-					</div>
-				</section>
-			{/if}
-		</div>
-	</aside>
+      <!-- Attributes -->
+      {#if tracker.properties?.attributes && Object.keys(tracker.properties.attributes).length > 0}
+        <section class="space-y-2">
+          <h3
+            class="text-sm font-medium text-zinc-600 uppercase tracking-wide m-0"
+          >
+            Attributes
+          </h3>
+          <div class="space-y-1">
+            {#each Object.entries(tracker.properties.attributes).sort( ([a], [b]) => a.localeCompare(b) ) as [key, value]}
+              <div class="flex items-center justify-between">
+                <span class="text-xs text-zinc-600">{key}:</span>
+                <button
+                  class="text-sm text-zinc-800 hover:text-white transition-colors cursor-pointer font-mono bg-lime-400 hover:bg-lime-500 px-2 py-1 rounded max-w-[200px] truncate"
+                  onclick={() => copyToClipboard(value)}
+                  title={value}
+                >
+                  {value}
+                </button>
+              </div>
+            {/each}
+          </div>
+        </section>
+      {/if}
+    </div>
+  </aside>
 {/snippet}

--- a/src/lib/modules/SvgManager/index.svelte
+++ b/src/lib/modules/SvgManager/index.svelte
@@ -1,192 +1,191 @@
 <script lang="ts">
-	import Measurements from "@/lib/components/Measurements.svelte";
-	import Ruler from "@/lib/components/Ruler.svelte";
-	import { TrackersStore, UIStore } from "@/lib/store/index.svelte";
-	import { type SvelteHTMLElements } from "svelte/elements";
+  import Measurements from "@/lib/components/Measurements.svelte";
+  import Ruler from "@/lib/components/Ruler.svelte";
+  import { TrackersStore, UIStore } from "@/lib/store/index.svelte";
+  import { type SvelteHTMLElements } from "svelte/elements";
 
-	type SVGElement = SvelteHTMLElements["svg"];
+  type SVGElement = SvelteHTMLElements["svg"];
 
-	interface Props extends SVGElement {}
+  interface Props extends SVGElement {}
 
-	const trackersStore = getContext<TrackersStore>("trackersStore");
-	const uiStore = getContext<UIStore>("uiStore");
+  const trackersStore = getContext<TrackersStore>("trackersStore");
+  const uiStore = getContext<UIStore>("uiStore");
 
-	let tracker = $derived(trackersStore.current);
+  let tracker = $derived(trackersStore.current);
 
-	let props: Props = $props();
+  let props: Props = $props();
 </script>
 
 <svg class="hidden">
-	<defs>
-		<filter
-			id="invertedOutline"
-			x="-50%"
-			y="-50%"
-			width="200%"
-			height="200%"
-			color-interpolation-filters="sRGB"
-			filterUnits="objectBoundingBox"
-			primitiveUnits="userSpaceOnUse"
-		>
-			<feColorMatrix
-				in="SourceGraphic"
-				type="matrix"
-				values="
+  <defs>
+    <filter
+      id="invertedOutline"
+      x="-50%"
+      y="-50%"
+      width="200%"
+      height="200%"
+      color-interpolation-filters="sRGB"
+      filterUnits="objectBoundingBox"
+      primitiveUnits="userSpaceOnUse"
+    >
+      <feColorMatrix
+        in="SourceGraphic"
+        type="matrix"
+        values="
 					-1 0 0 0 1
 						0 -1 0 0 1
 						0 0 -1 0 1
 						0 0 0 1 0
 				"
-				result="invertedColor"
-			/>
+        result="invertedColor"
+      />
 
-			<feMorphology
-				in="invertedColor"
-				operator="dilate"
-				radius="2"
-				result="outline"
-			/>
+      <feMorphology
+        in="invertedColor"
+        operator="dilate"
+        radius="2"
+        result="outline"
+      />
 
-			<feBlend in="SourceGraphic" in2="outline" mode="normal" />
-		</filter>
+      <feBlend in="SourceGraphic" in2="outline" mode="normal" />
+    </filter>
 
-		<filter id="bwFilter" color-interpolation-filters="sRGB">
-			<!-- Convert to grayscale based on luminance -->
-			<feColorMatrix
-				type="matrix"
-				values="0.2126 0.7152 0.0722 0 0
+    <filter id="bwFilter" color-interpolation-filters="sRGB">
+      <!-- Convert to grayscale based on luminance -->
+      <feColorMatrix
+        type="matrix"
+        values="0.2126 0.7152 0.0722 0 0
                         0.2126 0.7152 0.0722 0 0
                         0.2126 0.7152 0.0722 0 0
                         0 0 0 1 0"
-			/>
-			<!-- Expand edges slightly to clean up any fringing -->
-			<feMorphology operator="dilate" radius="2" />
-			<!-- Apply the threshold to determine if the color should be black or white -->
-			<feComponentTransfer>
-				<feFuncR type="linear" slope="-255" intercept="128" />
-				<feFuncG type="linear" slope="-255" intercept="128" />
-				<feFuncB type="linear" slope="-255" intercept="128" />
-			</feComponentTransfer>
-			<!-- Composite step to clean up the result -->
-			<feComposite operator="in" in2="SourceGraphic" />
-		</filter>
+      />
+      <!-- Expand edges slightly to clean up any fringing -->
+      <feMorphology operator="dilate" radius="2" />
+      <!-- Apply the threshold to determine if the color should be black or white -->
+      <feComponentTransfer>
+        <feFuncR type="linear" slope="-255" intercept="128" />
+        <feFuncG type="linear" slope="-255" intercept="128" />
+        <feFuncB type="linear" slope="-255" intercept="128" />
+      </feComponentTransfer>
+      <!-- Composite step to clean up the result -->
+      <feComposite operator="in" in2="SourceGraphic" />
+    </filter>
 
-		<filter
-			id="colorInversion"
-			color-interpolation-filters="sRGB"
-			filterUnits="objectBoundingBox"
-			primitiveUnits="userSpaceOnUse"
-		>
-			<feColorMatrix
-				type="matrix"
-				values="0.2126 0.7152 0.0722 0 0
+    <filter
+      id="colorInversion"
+      color-interpolation-filters="sRGB"
+      filterUnits="objectBoundingBox"
+      primitiveUnits="userSpaceOnUse"
+    >
+      <feColorMatrix
+        type="matrix"
+        values="0.2126 0.7152 0.0722 0 0
 								0.2126 0.7152 0.0722 0 0
 								0.2126 0.7152 0.0722 0 0
 								0 0 0 1 0"
-				x="0%"
-				y="0%"
-				width="100%"
-				height="100%"
-				in="dropShadow"
-				result="colormatrix"
-			/>
-			<feMorphology
-				operator="dilate"
-				radius="2 2"
-				x="0%"
-				y="0%"
-				width="100%"
-				height="100%"
-				in="colormatrix"
-				result="morphology1"
-			/>
-			<feComponentTransfer
-				x="0%"
-				y="0%"
-				width="100%"
-				height="100%"
-				in="morphology1"
-				result="componentTransfer"
-			>
-				<feFuncR type="linear" slope="-255" intercept="128" />
-				<feFuncG type="linear" slope="-255" intercept="128" />
-				<feFuncB type="linear" slope="-255" intercept="128" />
-				<feFuncA type="linear" slope="1" intercept="0" />
-			</feComponentTransfer>
-			<feComposite
-				in="componentTransfer"
-				in2="SourceGraphic"
-				operator="in"
-				x="0%"
-				y="0%"
-				width="100%"
-				height="100%"
-				result="composite"
-			/>
-		</filter>
+        x="0%"
+        y="0%"
+        width="100%"
+        height="100%"
+        in="dropShadow"
+        result="colormatrix"
+      />
+      <feMorphology
+        operator="dilate"
+        radius="2 2"
+        x="0%"
+        y="0%"
+        width="100%"
+        height="100%"
+        in="colormatrix"
+        result="morphology1"
+      />
+      <feComponentTransfer
+        x="0%"
+        y="0%"
+        width="100%"
+        height="100%"
+        in="morphology1"
+        result="componentTransfer"
+      >
+        <feFuncR type="linear" slope="-255" intercept="128" />
+        <feFuncG type="linear" slope="-255" intercept="128" />
+        <feFuncB type="linear" slope="-255" intercept="128" />
+        <feFuncA type="linear" slope="1" intercept="0" />
+      </feComponentTransfer>
+      <feComposite
+        in="componentTransfer"
+        in2="SourceGraphic"
+        operator="in"
+        x="0%"
+        y="0%"
+        width="100%"
+        height="100%"
+        result="composite"
+      />
+    </filter>
 
-		<filter
-			id="outline"
-			color-interpolation-filters="linearRGB"
-			filterUnits="objectBoundingBox"
-			primitiveUnits="userSpaceOnUse"
-		>
-			<feMorphology
-				operator="dilate"
-				radius="1.5 1.5"
-				in="SourceAlpha"
-				result="morphology"
-			/>
-			<feFlood flood-color="#ffffff" flood-opacity="1" result="flood" />
-			<feComposite
-				in="flood"
-				in2="morphology"
-				operator="in"
-				result="composite"
-			/>
-			<feMerge result="merge">
-				<feMergeNode in="composite" result="mergeNode" />
-				<feMergeNode in="SourceGraphic" result="mergeNode1" />
-			</feMerge>
-		</filter>
-	</defs>
+    <filter
+      id="outline"
+      color-interpolation-filters="linearRGB"
+      filterUnits="objectBoundingBox"
+      primitiveUnits="userSpaceOnUse"
+    >
+      <feMorphology
+        operator="dilate"
+        radius="1.5 1.5"
+        in="SourceAlpha"
+        result="morphology"
+      />
+      <feFlood flood-color="#ffffff" flood-opacity="1" result="flood" />
+      <feComposite
+        in="flood"
+        in2="morphology"
+        operator="in"
+        result="composite"
+      />
+      <feMerge result="merge">
+        <feMergeNode in="composite" result="mergeNode" />
+        <feMergeNode in="SourceGraphic" result="mergeNode1" />
+      </feMerge>
+    </filter>
+  </defs>
 </svg>
 
 <svg class="fixed inset-0 w-screen h-screen pointer-events-none" {...props}>
-	<Ruler />
-	<Measurements gridSize={8} color="#3b82f6" zIndex={10000000001} />
-	{#if 		uiStore.svg.showDistances && tracker?.parentOfTarget &&
-			tracker.lines}
-		<g filter="url(#outline)">
-			{#each [...tracker.lockedLines, ...tracker.lines] as line}
-				<line
-					class="text-lime-300"
-					x1={line.x1}
-					y1={line.y1}
-					x2={line.x2}
-					y2={line.y2}
-					stroke-dasharray={line.distance < 0 ? "4,4" : "none"}
-					stroke={line.color}
-					stroke-width={line.distance < 0 ? 0.5 : 2}
-				/>
-				{#if line.type}
-					<text
-						class="font-bold tracking-wide"
-						x={line.type === "top" || line.type === "bottom"
-							? line.x1 + 15
-							: (line.x1 + line.x2) / 2}
-						y={line.type === "left" || line.type === "right"
-							? line.y1 - 15
-							: (line.y1 + line.y2) / 2}
-						font-family="Inter, system-ui, sans-serif"
-						dominant-baseline="middle"
-						fill={line.color}
-						font-size="12"
-					>
-						{Math.abs(line.distance)} px
-					</text>
-				{/if}
-			{/each}
-		</g>
-	{/if}
+  <Ruler />
+  <Measurements gridSize={8} color="#3b82f6" zIndex={10000000001} />
+  {#if uiStore.svg.showDistances && tracker?.parentOfTarget && tracker.lines}
+    <g filter="url(#outline)">
+      {#each [...tracker.lockedLines, ...tracker.lines] as line}
+        <line
+          class="text-lime-300"
+          x1={line.x1}
+          y1={line.y1}
+          x2={line.x2}
+          y2={line.y2}
+          stroke-dasharray={line.distance < 0 ? "4,4" : "none"}
+          stroke={line.color}
+          stroke-width={line.distance < 0 ? 0.5 : 2}
+        />
+        {#if line.type}
+          <text
+            class="font-bold tracking-wide"
+            x={line.type === "top" || line.type === "bottom"
+              ? line.x1 + 15
+              : (line.x1 + line.x2) / 2}
+            y={line.type === "left" || line.type === "right"
+              ? line.y1 - 15
+              : (line.y1 + line.y2) / 2}
+            font-family="Inter, system-ui, sans-serif"
+            dominant-baseline="middle"
+            fill={line.color}
+            font-size="12"
+          >
+            {Math.abs(line.distance)} px
+          </text>
+        {/if}
+      {/each}
+    </g>
+  {/if}
 </svg>


### PR DESCRIPTION
## Summary

- Update Cursor issue-refinement workflow to treat **GitHub issues** as the source of truth (no local `docs/ISSUE_REFINEMENTS.md`).
- Adjust `skill-maintenance`, `skill-hygiene`, and `pr-from-issue` skills accordingly.
- Reformat and tidy overlay-related Svelte (measurements, ruler, side panel, SVG manager, extension settings, shared components).

## Test plan

- [x] `pnpm check`
- [x] `pnpm lint`
- [ ] Smoke: open extension on a page, toolbar, side panel, measurements/ruler as touched

Made with [Cursor](https://cursor.com)